### PR TITLE
Support for multiple tables

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,4 +1,5 @@
-<table {!! $attributes !!} style="width:100%">
+@php($id = 'datatable-' . uniqid())
+<table id="{{ $id }}" {!! $attributes !!} style="width:100%">
     <thead>
     <tr>
         @foreach($headers as $header)
@@ -19,7 +20,7 @@
 
 <script>
     $(function () {
-        $('.dataTable').DataTable(
+        $('#{{ $id }}').DataTable(
             {!! $options !!}
         )
     })


### PR DESCRIPTION
Thanks for the nice widget!

I want to use multiple data tables in one screen as follows.

```php
        $tabs = (new Tab)
            ->add(__('User'), new DataTable)
            ->add(__('History'), new DataTable);
```

However, I got the following error dialog, and it didn't seem to support multiple tables.
<img width="460" alt="dialog" src="https://user-images.githubusercontent.com/59242656/107207619-d98a3a80-6a43-11eb-887c-a5be06b9e86d.png">



When I looked into it, 
I found out that the error was caused by trying to initialize data-tables multiple times.
Therefore, I modified the blade file to allow multiple tables.
